### PR TITLE
Add agent-oriented documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# Wake Time Calculator – Agent Guide
+
+## Scope
+These instructions apply to the entire repository.
+
+## Project Snapshot
+- **Entry point**: `wake.html` contains the complete UI, styling, and client-side logic.
+- **Supporting files**: `index.html` (redirect for GitHub Pages), `README.md` (user-facing overview), `package.json` (utility scripts), `.gitignore` (excludes `wake.min.html`, `node_modules/`, etc.).
+- **Tech stack**: vanilla HTML/CSS/JS with TailwindCSS + DaisyUI loaded from CDNs; there is no bundler or build pipeline.
+
+## Workflow Checklist
+1. Keep edits narrowly focused on the requested change; avoid broad refactors or introducing new tooling.
+2. Preserve the single-file architecture—do not add frameworks, build steps, or external asset pipelines.
+3. Match existing formatting and naming conventions (the file is Prettier-friendly but largely hand-formatted).
+4. Prefer `rg`, `sed -n`, or targeted search to navigate `wake.html`; it is long, so avoid full-file rewrites.
+5. Update or consult `agent.md` for deep technical details (APIs, algorithms, storage keys) when the change touches weather logic.
+
+## Scripts & Commands
+Run these from the repository root:
+
+| Purpose | Command |
+| --- | --- |
+| Serve locally (Node) | `npm start` → http://localhost:8000/wake.html |
+| Serve locally (Python) | `npm run serve` or `python3 -m http.server 8000` |
+| Format `wake.html` | `npm run format` |
+| HTML validation | `npm run validate` |
+| Lightweight smoke check | `npm run smoke` |
+
+Always run `npm run format` and `npm run validate` after making changes to `wake.html`. Execute `npm run smoke` if you modified network calls or markup that could impact loading.
+
+## Testing Expectations
+There is no automated test suite beyond the scripts above. Manually verify the wake-time output when crossing midnight and ensure the awareness bar still renders when geolocation is unavailable.
+
+## Common Gotchas
+- LocalStorage keys are prefixed with `wake:`; keep names stable to avoid breaking saved data.
+- The awareness bar caches API responses for 15 minutes—respect `CACHE_DURATION` and existing caching helpers.
+- Trail wetness categories are consumed in multiple spots (badging + text); adjust both when modifying thresholds.
+- Do not commit `wake.min.html` or `node_modules/` (both are ignored but double-check before committing).
+
+## Resources
+- Use `README.md` for high-level project context.
+- Use `agent.md` for detailed algorithm notes and API references.
+- Tailwind components rely on CDN versions defined in the `<head>` of `wake.html`; keep the order intact when editing.

--- a/docs/wake-html-map.md
+++ b/docs/wake-html-map.md
@@ -1,0 +1,63 @@
+# `wake.html` Maintainability Map
+
+This document highlights the major regions of `wake.html` so future agents can jump to the correct section quickly.
+
+## High-level layout
+- **Lines ~1–220** – `<head>`: CDN bootstrapping (Tailwind runtime script, DaisyUI stylesheet) and bespoke CSS including responsive tweaks for the awareness bar and form layout.
+- **Lines ~220–420** – Awareness bar markup (`<section id="awareness">`): contains the location controls, the metric grid, inline clothes suggestion, and credits.
+- **Lines ~420–620** – Main calculator card: headline output, form inputs, and summary breakdown region.
+- **Lines ~620–end** – Single `<script>` block wrapping the entire client logic in an IIFE. All JS lives here.
+
+> Tip: use `sed -n '600,800p' wake.html` (adjust numbers) to peek at targeted script slices without loading the whole file.
+
+## Awareness bar quick reference
+Key element IDs (search for each when editing):
+
+| ID | Purpose |
+| --- | --- |
+| `awCity` | Badge showing the resolved location label. Class switched between success/warning. |
+| `awDawn` | `<time>` element for tomorrow’s dawn, formatted in the location time zone. |
+| `awWindChill` | Displays wind chill (or fallback temperature). Adds `.bad` class when ≤ 15 °F. |
+| `awPoP` | Precipitation probability. Adds `.bad` when ≥ 60 %. |
+| `awWetBulb` | Wet-bulb temperature. Adds `.bad` when ≥ 75 °F. |
+| `awWetness` | Trail wetness category + numeric inch value when available. `.bad` when ≥ 0.40". |
+| `awMsg` | Status line communicating loading/errors. |
+| `useMyLocation` / `setPlace` / `placeQuery` | Controls for geolocation + manual city lookup. |
+| `clothesInline` | Inline text for “Clothes at dawn” suggestion. |
+
+## Script structure
+Inside the closing `<script>` block:
+
+1. **Constants & utilities**
+   - `PREP_MINUTES`, `MINUTES_PER_DAY`, time conversion helpers (`toMinutes`, `fromMinutes`, `format12`, etc.).
+   - Location defaults and the `DIRT_LOCATIONS` set for the headlamp badge logic.
+2. **DOM caches**
+   - `elements` – references to form fields, outputs, and stateful containers.
+   - `wels` – references used exclusively by the awareness bar UI.
+3. **Persistence helpers**
+   - `storageKeys`, `loadValues()`, `saveValues()` for calculator state.
+   - `weatherStorage`, `readCoords()`, `saveCoords()` for awareness-bar state.
+4. **Scheduling logic**
+   - `recalculate()` calculates wake time totals and updates the summary via `renderResult()` / `showEmptyState()`.
+5. **Weather + dawn fetching**
+   - `fetchWithCache()` implements the 15-minute cache shared by dawn, weather, and wetness requests.
+   - `fetchDawn()`, `fetchWeatherAround()`, `fetchWetnessInputs()`, `computeWetness()`, `categorizeWetness()` handle API calls and derived metrics.
+   - `reverseGeocode()` falls back to Nominatim when Open-Meteo reverse lookup fails.
+6. **Awareness rendering**
+   - `renderAwareness()` updates the DOM, toggling `.bad` threshold classes and the run-location headlamp badge via `updateLocationHeadlamp()`.
+   - `refreshAwareness()` orchestrates API calls with request-id deduping and abort control.
+   - `attachAwarenessEvents()` wires geolocation + manual search buttons.
+   - `initAwareness()` bootstraps the bar with cached coords or fresh geolocation.
+7. **Event wiring**
+   - `attachEvents()` sets up `input` listeners for recalculation, travel override toggles, and ensures travel time syncs with the selected location option.
+   - DOM ready guard kicks off `loadValues()`, `attachEvents()`, `recalculate()`, `initAwareness()`, and `updateLocationHeadlamp()`.
+
+## Useful search anchors
+- `<!-- Tailwind runtime CDN` – start of `<head>` block.
+- `<section class="awareness"` – awareness markup anchor.
+- `const PREP_MINUTES` – start of script constants.
+- `const weatherStorage = {` – beginning of weather persistence helpers.
+- `const refreshAwareness = async` – main orchestrator for weather updates.
+- `const recalculate = () => {` – calculator computation logic.
+
+Keeping these anchors handy makes it easier to insert new functionality without disrupting the rest of the monolithic file.


### PR DESCRIPTION
## Summary
- add a top-level `AGENTS.md` with workflow, commands, and common gotchas for future coding agents
- document the structure of the monolithic `wake.html` in `docs/wake-html-map.md` to speed up navigation

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68ceda6493548330951dd0975e0971e6