### PR TITLE
Use primary-time clamp sizing for chosen wake display

### DIFF
--- a/wake.html
+++ b/wake.html
@@ -355,7 +355,7 @@ body {
         <h1 class="text-2xl md:text-3xl font-bold tracking-tight text-base-content mb-2">
           Wake Time
         </h1>
-        <div class="text-5xl md:text-6xl font-bold text-primary mb-3" id="chosenWake">--:--</div>
+        <div class="primary-time font-bold text-primary mb-3" id="chosenWake">--:--</div>
         <div class="text-sm text-base-content/70 space-x-4">
           <span>Latest possible: <span id="latestWake" class="font-semibold">--:--</span></span>
           <span>•</span>


### PR DESCRIPTION
## Summary
- swap the Wake Time display element to use the existing `.primary-time` utility class
- keep the existing font weight and color spacing utilities so the clamp sizing applies across breakpoints

## Testing
- npm run format
- npm run validate

------
https://chatgpt.com/codex/tasks/task_e_68cedf9bc3b483308a73175ffc1530ee