### PR TITLE
Improve smoke test wait logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format": "npx prettier --write wake.html",
     "validate": "npx html-validate wake.html",
     "minify": "npx html-minifier-terser wake.html -o wake.min.html --collapse-whitespace --remove-comments --minify-css --minify-js",
-    "smoke": "(python3 -m http.server 8001 & PID=$!; sleep 0.6; curl -sS -I http://localhost:8001/wake.html || true; kill $PID)"
+    "smoke": "(python3 -m http.server 8001 & PID=$!; success=0; for attempt in $(seq 1 10); do if curl -sS -I http://localhost:8001/wake.html; then success=1; break; fi; sleep 0.5; done; kill $PID; test $success -eq 1)"
   },
   "devDependencies": {},
   "keywords": ["wake-time", "calculator", "weather", "running"],


### PR DESCRIPTION
## Summary
- replace the smoke script's fixed delay with a retry loop that polls for the server response
- remove the `|| true` guard so the smoke test fails when the server never responds while still shutting down the helper server

## Testing
- npm run smoke


------
https://chatgpt.com/codex/tasks/task_e_68cedf86af8483309953979b21f09803