### PR TITLE
Refactor unit tests to run on Node test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "A wake time calculator with weather awareness for runners",
   "private": true,
+  "type": "module",
   "scripts": {
     "test": "playwright test",
     "test:ui": "playwright test --ui",
@@ -16,7 +17,7 @@
     "test:legacy": "playwright test tests/core.spec.js",
     "test:modular": "playwright test tests/integration/modular.test.js",
     "test:full-modular": "playwright test tests/integration/full-modular.test.js",
-    "test:unit": "playwright test tests/unit/",
+    "test:unit": "node --test tests/unit",
     "test:variants": "playwright test tests/core.spec.js tests/integration/modular.test.js tests/integration/full-modular.test.js",
     "test:performance": "playwright test tests/performance-comparison.spec.js",
     "test:smoke": "playwright test --grep='should load and display basic interface'",

--- a/tests/unit/calculator.test.js
+++ b/tests/unit/calculator.test.js
@@ -1,135 +1,123 @@
-import { test, expect } from '@playwright/test';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
 import {
   calculateWakeTime,
   toMinutes,
   fromMinutes,
   format12,
-  sanitizeMinutes
+  sanitizeMinutes,
 } from '../../js/core/calculator.js';
 
-test.describe('Calculator Module - Unit Tests', () => {
+test('calculator: toMinutes converts time string to minutes', () => {
+  assert.strictEqual(toMinutes('00:00'), 0);
+  assert.strictEqual(toMinutes('01:00'), 60);
+  assert.strictEqual(toMinutes('08:30'), 510);
+  assert.strictEqual(toMinutes('23:59'), 1439);
+});
 
-  test.describe('toMinutes', () => {
-    test('converts time string to minutes', () => {
-      expect(toMinutes('00:00')).toBe(0);
-      expect(toMinutes('01:00')).toBe(60);
-      expect(toMinutes('08:30')).toBe(510);
-      expect(toMinutes('23:59')).toBe(1439);
-    });
+test('calculator: fromMinutes converts minutes to HH:MM', () => {
+  assert.strictEqual(fromMinutes(0), '00:00');
+  assert.strictEqual(fromMinutes(60), '01:00');
+  assert.strictEqual(fromMinutes(510), '08:30');
+  assert.strictEqual(fromMinutes(1439), '23:59');
+});
+
+test('calculator: fromMinutes wraps negative values within a day', () => {
+  assert.strictEqual(fromMinutes(-60), '23:00');
+  assert.strictEqual(fromMinutes(-120), '22:00');
+});
+
+test('calculator: fromMinutes wraps values beyond 24 hours', () => {
+  assert.strictEqual(fromMinutes(1440), '00:00');
+  assert.strictEqual(fromMinutes(1500), '01:00');
+});
+
+test('calculator: format12 converts to 12-hour clock', () => {
+  assert.strictEqual(format12('00:00'), '12:00 AM');
+  assert.strictEqual(format12('01:30'), '1:30 AM');
+  assert.strictEqual(format12('12:00'), '12:00 PM');
+  assert.strictEqual(format12('13:45'), '1:45 PM');
+  assert.strictEqual(format12('23:59'), '11:59 PM');
+});
+
+test('calculator: sanitizeMinutes keeps valid values', () => {
+  assert.strictEqual(sanitizeMinutes(0, 10), 0);
+  assert.strictEqual(sanitizeMinutes(45, 10), 45);
+  assert.strictEqual(sanitizeMinutes(999, 10), 999);
+});
+
+test('calculator: sanitizeMinutes falls back for invalid values', () => {
+  assert.strictEqual(sanitizeMinutes('abc', 10), 10);
+  assert.strictEqual(sanitizeMinutes(-5, 10), 10);
+  assert.strictEqual(sanitizeMinutes(1000, 10), 10);
+  assert.strictEqual(sanitizeMinutes(Number.NaN, 10), 10);
+});
+
+test('calculator: calculateWakeTime computes schedule for morning meeting', () => {
+  const result = calculateWakeTime({
+    meeting: '08:00',
+    runMinutes: 45,
+    travelMinutes: 20,
+    breakfastMinutes: 15,
   });
 
-  test.describe('fromMinutes', () => {
-    test('converts minutes to time string', () => {
-      expect(fromMinutes(0)).toBe('00:00');
-      expect(fromMinutes(60)).toBe('01:00');
-      expect(fromMinutes(510)).toBe('08:30');
-      expect(fromMinutes(1439)).toBe('23:59');
-    });
+  assert.strictEqual(result.wakeTime, '05:55');
+  assert.strictEqual(result.wakeTime12, '5:55 AM');
+  assert.strictEqual(result.totalMinutes, 125);
+  assert.strictEqual(result.previousDay, false);
+});
 
-    test('handles negative minutes correctly', () => {
-      expect(fromMinutes(-60)).toBe('23:00');
-      expect(fromMinutes(-120)).toBe('22:00');
-    });
-
-    test('handles minutes over 24 hours', () => {
-      expect(fromMinutes(1440)).toBe('00:00');
-      expect(fromMinutes(1500)).toBe('01:00');
-    });
+test('calculator: calculateWakeTime handles previous-day wake ups', () => {
+  const result = calculateWakeTime({
+    meeting: '02:00',
+    runMinutes: 90,
+    travelMinutes: 30,
+    breakfastMinutes: 45,
   });
 
-  test.describe('format12', () => {
-    test('formats 24-hour time to 12-hour', () => {
-      expect(format12('00:00')).toBe('12:00 AM');
-      expect(format12('01:30')).toBe('1:30 AM');
-      expect(format12('12:00')).toBe('12:00 PM');
-      expect(format12('13:45')).toBe('1:45 PM');
-      expect(format12('23:59')).toBe('11:59 PM');
-    });
+  assert.strictEqual(result.previousDay, true);
+  assert.ok(result.wakeTime12.includes('PM'));
+});
+
+test('calculator: calculateWakeTime supports zero optional activities', () => {
+  const result = calculateWakeTime({
+    meeting: '09:00',
+    runMinutes: 0,
+    travelMinutes: 0,
+    breakfastMinutes: 0,
   });
 
-  test.describe('sanitizeMinutes', () => {
-    test('returns valid numbers unchanged', () => {
-      expect(sanitizeMinutes(0, 10)).toBe(0);
-      expect(sanitizeMinutes(45, 10)).toBe(45);
-      expect(sanitizeMinutes(999, 10)).toBe(999);
-    });
+  assert.strictEqual(result.wakeTime, '08:15');
+  assert.strictEqual(result.totalMinutes, 45);
+  assert.strictEqual(result.previousDay, false);
+});
 
-    test('returns fallback for invalid values', () => {
-      expect(sanitizeMinutes('abc', 10)).toBe(10);
-      expect(sanitizeMinutes(-5, 10)).toBe(10);
-      expect(sanitizeMinutes(1000, 10)).toBe(10);
-      expect(sanitizeMinutes(NaN, 10)).toBe(10);
-    });
+test('calculator: calculateWakeTime returns intermediate times', () => {
+  const result = calculateWakeTime({
+    meeting: '08:00',
+    runMinutes: 60,
+    travelMinutes: 15,
+    breakfastMinutes: 20,
   });
 
-  test.describe('calculateWakeTime', () => {
-    test('calculates wake time for morning meeting', () => {
-      const result = calculateWakeTime({
-        meeting: '08:00',
-        runMinutes: 45,
-        travelMinutes: 20,
-        breakfastMinutes: 15
-      });
+  assert.strictEqual(result.latestWakeTime, '06:15');
+  assert.strictEqual(result.runStartTime, '06:00');
+});
 
-      expect(result.wakeTime).toBe('05:55');
-      expect(result.wakeTime12).toBe('5:55 AM');
-      expect(result.totalMinutes).toBe(125); // 45 + 45 + 20 + 15
-      expect(result.previousDay).toBe(false);
-    });
+test('calculator: calculateWakeTime includes duration breakdown', () => {
+  const result = calculateWakeTime({
+    meeting: '07:30',
+    runMinutes: 30,
+    travelMinutes: 10,
+    breakfastMinutes: 5,
+  });
 
-    test('handles previous day calculation', () => {
-      const result = calculateWakeTime({
-        meeting: '02:00',
-        runMinutes: 90,
-        travelMinutes: 30,
-        breakfastMinutes: 45
-      });
-
-      expect(result.previousDay).toBe(true);
-      expect(result.wakeTime12).toContain('PM');
-    });
-
-    test('calculates with no optional activities', () => {
-      const result = calculateWakeTime({
-        meeting: '09:00',
-        runMinutes: 0,
-        travelMinutes: 0,
-        breakfastMinutes: 0
-      });
-
-      expect(result.wakeTime).toBe('08:15'); // 9:00 - 45 min prep
-      expect(result.totalMinutes).toBe(45);
-      expect(result.previousDay).toBe(false);
-    });
-
-    test('provides correct intermediate times', () => {
-      const result = calculateWakeTime({
-        meeting: '08:00',
-        runMinutes: 60,
-        travelMinutes: 15,
-        breakfastMinutes: 20
-      });
-
-      // Latest wake = meeting - prep - run = 8:00 - 45 - 60 = 6:15
-      expect(result.latestWakeTime).toBe('06:15');
-
-      // Run start = meeting - prep - run - travel = 8:00 - 45 - 60 - 15 = 6:00
-      expect(result.runStartTime).toBe('06:00');
-    });
-
-    test('returns correct duration breakdown', () => {
-      const result = calculateWakeTime({
-        meeting: '10:00',
-        runMinutes: 30,
-        travelMinutes: 25,
-        breakfastMinutes: 15
-      });
-
-      expect(result.durations.prep).toBe(45);
-      expect(result.durations.run).toBe(30);
-      expect(result.durations.travel).toBe(25);
-      expect(result.durations.breakfast).toBe(15);
-      expect(result.durations.prepBeforeRun).toBe(20);
-    });
+  assert.deepStrictEqual(result.durations, {
+    prep: 45,
+    prepBeforeRun: 20,
+    run: 30,
+    travel: 10,
+    breakfast: 5,
   });
 });

--- a/tests/unit/dawn.test.js
+++ b/tests/unit/dawn.test.js
@@ -1,183 +1,92 @@
-import { test, expect } from '@playwright/test';
+import test from 'node:test';
+import assert from 'node:assert/strict';
 
-test.describe('Dawn Module - Unit Tests', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/index-modular.html');
-  });
+import {
+  checkDaylightNeeded,
+  setTestDawn,
+} from '../../js/modules/dawn.js';
 
-  test.describe('checkDaylightNeeded', () => {
-    test('returns false when no dawn date provided', async ({ page }) => {
-      const result = await page.evaluate(async () => {
-        const { checkDaylightNeeded } = await import('./js/modules/dawn.js');
-        return checkDaylightNeeded(360, null); // 6:00 AM
-      });
+test('dawn: checkDaylightNeeded returns false without dawn data', () => {
+  const result = checkDaylightNeeded(360, null);
+  assert.deepStrictEqual(result, { needed: false, message: null });
+});
 
-      expect(result.needed).toBe(false);
-      expect(result.message).toBe(null);
-    });
+test('dawn: checkDaylightNeeded warns when run is before dawn', () => {
+  const dawn = new Date();
+  dawn.setHours(7, 0, 0, 0);
 
-    test('returns true when running before dawn', async ({ page }) => {
-      const result = await page.evaluate(async () => {
-        const { checkDaylightNeeded } = await import('./js/modules/dawn.js');
+  const result = checkDaylightNeeded(390, dawn);
+  assert.strictEqual(result.needed, true);
+  assert.strictEqual(result.message, 'Check daylight (30 min before dawn)');
+  assert.strictEqual(result.minutesBefore, 30);
+});
 
-        // Dawn at 7:00 AM (420 minutes)
-        const dawnDate = new Date();
-        dawnDate.setHours(7, 0, 0, 0);
+test('dawn: checkDaylightNeeded warns at dawn', () => {
+  const dawn = new Date();
+  dawn.setHours(6, 30, 0, 0);
 
-        // Run starts at 6:30 AM (390 minutes) - 30 minutes before dawn
-        return checkDaylightNeeded(390, dawnDate);
-      });
+  const result = checkDaylightNeeded(390, dawn);
+  assert.strictEqual(result.needed, true);
+  assert.strictEqual(result.message, 'Check daylight (at dawn)');
+  assert.strictEqual(result.minutesBefore, 0);
+});
 
-      expect(result.needed).toBe(true);
-      expect(result.message).toBe('Check daylight (30 min before dawn)');
-      expect(result.minutesBefore).toBe(30);
-    });
+test('dawn: checkDaylightNeeded allows runs after dawn', () => {
+  const dawn = new Date();
+  dawn.setHours(6, 0, 0, 0);
 
-    test('returns true when running exactly at dawn', async ({ page }) => {
-      const result = await page.evaluate(async () => {
-        const { checkDaylightNeeded } = await import('./js/modules/dawn.js');
+  const result = checkDaylightNeeded(420, dawn);
+  assert.deepStrictEqual(result, { needed: false, message: null });
+});
 
-        // Dawn at 6:30 AM (390 minutes)
-        const dawnDate = new Date();
-        dawnDate.setHours(6, 30, 0, 0);
+test('dawn: checkDaylightNeeded handles wrap-around near midnight', () => {
+  const dawn = new Date();
+  dawn.setHours(6, 0, 0, 0);
 
-        // Run starts at exactly 6:30 AM (390 minutes)
-        return checkDaylightNeeded(390, dawnDate);
-      });
+  const result = checkDaylightNeeded(300, dawn);
+  assert.strictEqual(result.needed, true);
+  assert.strictEqual(result.minutesBefore, 60);
+  assert.strictEqual(result.message, 'Check daylight (60 min before dawn)');
+});
 
-      expect(result.needed).toBe(true);
-      expect(result.message).toBe('Check daylight (at dawn)');
-      expect(result.minutesBefore).toBe(0);
-    });
+test('dawn: checkDaylightNeeded handles very early runs', () => {
+  const dawn = new Date();
+  dawn.setHours(7, 0, 0, 0);
 
-    test('returns false when running after dawn', async ({ page }) => {
-      const result = await page.evaluate(async () => {
-        const { checkDaylightNeeded } = await import('./js/modules/dawn.js');
+  const result = checkDaylightNeeded(240, dawn);
+  assert.strictEqual(result.needed, true);
+  assert.strictEqual(result.minutesBefore, 180);
+  assert.strictEqual(result.message, 'Check daylight (180 min before dawn)');
+});
 
-        // Dawn at 6:00 AM (360 minutes)
-        const dawnDate = new Date();
-        dawnDate.setHours(6, 0, 0, 0);
+test('dawn: setTestDawn produces exact time', () => {
+  const dawn = setTestDawn(6, 30);
+  assert.strictEqual(dawn.getHours(), 6);
+  assert.strictEqual(dawn.getMinutes(), 30);
+  assert.strictEqual(dawn.getSeconds(), 0);
+  assert.strictEqual(dawn.getMilliseconds(), 0);
+});
 
-        // Run starts at 7:00 AM (420 minutes) - 60 minutes after dawn
-        return checkDaylightNeeded(420, dawnDate);
-      });
+test('dawn: setTestDawn handles boundary values', () => {
+  const midnight = setTestDawn(0, 0);
+  assert.strictEqual(midnight.getHours(), 0);
+  assert.strictEqual(midnight.getMinutes(), 0);
 
-      expect(result.needed).toBe(false);
-      expect(result.message).toBe(null);
-    });
+  const noon = setTestDawn(12, 0);
+  assert.strictEqual(noon.getHours(), 12);
+  assert.strictEqual(noon.getMinutes(), 0);
 
-    test('handles edge case with minutes wrapping around midnight', async ({ page }) => {
-      const result = await page.evaluate(async () => {
-        const { checkDaylightNeeded } = await import('./js/modules/dawn.js');
+  const late = setTestDawn(23, 59);
+  assert.strictEqual(late.getHours(), 23);
+  assert.strictEqual(late.getMinutes(), 59);
+});
 
-        // Dawn at 6:00 AM (360 minutes)
-        const dawnDate = new Date();
-        dawnDate.setHours(6, 0, 0, 0);
+test('dawn: daylight helper integrates repeated calls', () => {
+  const testDawn = setTestDawn(6, 0);
+  const early = checkDaylightNeeded(300, testDawn);
+  const late = checkDaylightNeeded(420, testDawn);
 
-        // Run starts at 5:00 AM (300 minutes) - 60 minutes before dawn
-        return checkDaylightNeeded(300, dawnDate);
-      });
-
-      expect(result.needed).toBe(true);
-      expect(result.message).toBe('Check daylight (60 min before dawn)');
-      expect(result.minutesBefore).toBe(60);
-    });
-
-    test('handles very early runs (close to midnight)', async ({ page }) => {
-      const result = await page.evaluate(async () => {
-        const { checkDaylightNeeded } = await import('./js/modules/dawn.js');
-
-        // Dawn at 7:00 AM (420 minutes)
-        const dawnDate = new Date();
-        dawnDate.setHours(7, 0, 0, 0);
-
-        // Run starts at 4:00 AM (240 minutes) - 180 minutes before dawn
-        return checkDaylightNeeded(240, dawnDate);
-      });
-
-      expect(result.needed).toBe(true);
-      expect(result.message).toBe('Check daylight (180 min before dawn)');
-      expect(result.minutesBefore).toBe(180);
-    });
-  });
-
-  test.describe('setTestDawn', () => {
-    test('creates test dawn date with specified time', async ({ page }) => {
-      const result = await page.evaluate(async () => {
-        const { setTestDawn } = await import('./js/modules/dawn.js');
-
-        const testDawn = setTestDawn(6, 30);
-
-        return {
-          hours: testDawn.getHours(),
-          minutes: testDawn.getMinutes(),
-          seconds: testDawn.getSeconds(),
-          milliseconds: testDawn.getMilliseconds()
-        };
-      });
-
-      expect(result.hours).toBe(6);
-      expect(result.minutes).toBe(30);
-      expect(result.seconds).toBe(0);
-      expect(result.milliseconds).toBe(0);
-    });
-
-    test('handles edge cases for time values', async ({ page }) => {
-      const results = await page.evaluate(async () => {
-        const { setTestDawn } = await import('./js/modules/dawn.js');
-
-        return [
-          {
-            name: 'midnight',
-            dawn: setTestDawn(0, 0),
-            expectedHours: 0,
-            expectedMinutes: 0
-          },
-          {
-            name: 'noon',
-            dawn: setTestDawn(12, 0),
-            expectedHours: 12,
-            expectedMinutes: 0
-          },
-          {
-            name: 'late_evening',
-            dawn: setTestDawn(23, 59),
-            expectedHours: 23,
-            expectedMinutes: 59
-          }
-        ].map(test => ({
-          name: test.name,
-          hours: test.dawn.getHours(),
-          minutes: test.dawn.getMinutes(),
-          expectedHours: test.expectedHours,
-          expectedMinutes: test.expectedMinutes
-        }));
-      });
-
-      results.forEach(result => {
-        expect(result.hours).toBe(result.expectedHours);
-        expect(result.minutes).toBe(result.expectedMinutes);
-      });
-    });
-  });
-
-  test.describe('fetchDawn integration', () => {
-    test('caches and reuses dawn data', async ({ page }) => {
-      // This test verifies caching behavior without making real API calls
-      const result = await page.evaluate(async () => {
-        const { checkDaylightNeeded, setTestDawn } = await import('./js/modules/dawn.js');
-
-        // Test that the module can be imported and functions work together
-        const testDawn = setTestDawn(6, 0);
-        const check1 = checkDaylightNeeded(300, testDawn); // 5:00 AM, 60 min before
-        const check2 = checkDaylightNeeded(420, testDawn); // 7:00 AM, 60 min after
-
-        return { check1, check2 };
-      });
-
-      expect(result.check1.needed).toBe(true);
-      expect(result.check1.minutesBefore).toBe(60);
-      expect(result.check2.needed).toBe(false);
-    });
-  });
+  assert.strictEqual(early.needed, true);
+  assert.strictEqual(early.minutesBefore, 60);
+  assert.strictEqual(late.needed, false);
 });

--- a/tests/unit/helpers/environment.js
+++ b/tests/unit/helpers/environment.js
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+
+/**
+ * Temporarily patch a global value for the duration of a callback.
+ * Restores the original value even if the callback throws.
+ *
+ * @template T
+ * @param {keyof globalThis} key - Global property to patch
+ * @param {T} value - Temporary value
+ * @param {() => Promise<any> | any} callback - Work to perform while patched
+ * @returns {Promise<any>} Result of the callback
+ */
+export const withPatchedGlobal = async (key, value, callback) => {
+  const hadKey = Object.prototype.hasOwnProperty.call(globalThis, key);
+  const original = globalThis[key];
+
+  try {
+    if (value === undefined) {
+      delete globalThis[key];
+    } else {
+      globalThis[key] = value;
+    }
+
+    return await callback();
+  } finally {
+    if (hadKey) {
+      globalThis[key] = original;
+    } else {
+      delete globalThis[key];
+    }
+  }
+};
+
+/**
+ * Create a simple in-memory mock of the Web Storage API.
+ * @returns {Storage}
+ */
+export const createMockLocalStorage = () => {
+  const store = new Map();
+  return {
+    getItem(key) {
+      return store.has(key) ? store.get(key) : null;
+    },
+    setItem(key, value) {
+      store.set(key, String(value));
+    },
+    removeItem(key) {
+      store.delete(key);
+    },
+    clear() {
+      store.clear();
+    },
+    key(index) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    get length() {
+      return store.size;
+    },
+  };
+};
+
+/**
+ * Utility to await a timeout for async timing assertions.
+ * @param {number} ms - Milliseconds to wait
+ * @returns {Promise<void>}
+ */
+export const wait = (ms) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/**
+ * Assert helper for checking that async callbacks reject with a message.
+ * @param {() => Promise<any>} fn - Function expected to reject
+ * @param {string|RegExp} message - Expected message or pattern
+ */
+export const expectRejectsWithMessage = async (fn, message) => {
+  await assert.rejects(fn, (error) => {
+    assert.ok(error instanceof Error);
+    const actual = error.message;
+    if (message instanceof RegExp) {
+      return message.test(actual);
+    }
+    return actual === message;
+  });
+};

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -1,177 +1,133 @@
-import { test, expect } from '@playwright/test';
+import test from 'node:test';
+import assert from 'node:assert/strict';
 
-test.describe('Storage Module - Unit Tests', () => {
-  test.beforeEach(async ({ page }) => {
-    // Navigate to a test page that loads the modules
-    await page.goto('/index-modular.html');
+import { Storage } from '../../js/core/storage.js';
+import {
+  createMockLocalStorage,
+  withPatchedGlobal,
+} from './helpers/environment.js';
 
-    // Clear localStorage before each test
-    await page.evaluate(() => {
-      localStorage.clear();
+const runWithFreshStorage = (fn) =>
+  withPatchedGlobal('localStorage', createMockLocalStorage(), fn);
+
+test('storage: save/load handles primitive values', async () => {
+  await runWithFreshStorage(() => {
+    Storage.save('test:key', 'value');
+    assert.strictEqual(Storage.load('test:key'), 'value');
+
+    Storage.save('test:number', 123);
+    assert.strictEqual(Storage.load('test:number'), '123');
+
+    assert.strictEqual(Storage.load('missing', 'default'), 'default');
+    assert.strictEqual(Storage.load('missing'), null);
+  });
+});
+
+test('storage: saveFormValues and loadFormValues round-trip data', async () => {
+  await runWithFreshStorage(() => {
+    Storage.saveFormValues({
+      firstMeeting: '09:00',
+      run: 45,
+      travel: 20,
+      breakfast: 15,
+      location: 'park',
+    });
+
+    const loaded = Storage.loadFormValues();
+    assert.deepStrictEqual(loaded, {
+      firstMeeting: '09:00',
+      run: '45',
+      travel: '20',
+      breakfast: '15',
+      location: 'park',
     });
   });
+});
 
-  test.describe('save and load', () => {
-    test('saves and loads string values', async ({ page }) => {
-      const result = await page.evaluate(async () => {
-        const { Storage } = await import('./js/core/storage.js');
-        Storage.save('test:key', 'value');
-        return Storage.load('test:key');
-      });
-      expect(result).toBe('value');
-    });
-
-    test('saves and loads numeric values as strings', async ({ page }) => {
-      const result = await page.evaluate(async () => {
-        const { Storage } = await import('./js/core/storage.js');
-        Storage.save('test:number', 123);
-        return Storage.load('test:number');
-      });
-      expect(result).toBe('123');
-    });
-
-    test('returns default value when key not found', async ({ page }) => {
-      const result = await page.evaluate(async () => {
-        const { Storage } = await import('./js/core/storage.js');
-        return Storage.load('nonexistent', 'default');
-      });
-      expect(result).toBe('default');
-    });
-
-    test('returns null when key not found and no default', async ({ page }) => {
-      const result = await page.evaluate(async () => {
-        const { Storage } = await import('./js/core/storage.js');
-        return Storage.load('nonexistent');
-      });
-      expect(result).toBe(null);
+test('storage: loadFormValues returns defaults when empty', async () => {
+  await runWithFreshStorage(() => {
+    const loaded = Storage.loadFormValues();
+    assert.deepStrictEqual(loaded, {
+      firstMeeting: '08:30',
+      run: '0',
+      travel: '0',
+      breakfast: '0',
+      location: 'round-town',
     });
   });
+});
 
-  test.describe('saveFormValues and loadFormValues', () => {
-    test('saves and loads form values correctly', async ({ page }) => {
-      const loaded = await page.evaluate(async () => {
-        const { Storage } = await import('./js/core/storage.js');
-        const values = {
-          firstMeeting: '09:00',
-          run: 45,
-          travel: 20,
-          breakfast: 15,
-          location: 'park'
-        };
-        Storage.saveFormValues(values);
-        return Storage.loadFormValues();
-      });
+test('storage: weather location save/load', async () => {
+  await runWithFreshStorage(() => {
+    const location = {
+      lat: 42.3601,
+      lon: -71.0589,
+      city: 'Boston',
+      tz: 'America/New_York',
+    };
 
-      expect(loaded.firstMeeting).toBe('09:00');
-      expect(loaded.run).toBe('45');
-      expect(loaded.travel).toBe('20');
-      expect(loaded.breakfast).toBe('15');
-      expect(loaded.location).toBe('park');
-    });
+    Storage.saveWeatherLocation(location);
+    const loaded = Storage.loadWeatherLocation();
 
-    test('loads defaults for missing values', async ({ page }) => {
-      const loaded = await page.evaluate(async () => {
-        const { Storage } = await import('./js/core/storage.js');
-        return Storage.loadFormValues();
-      });
-
-      expect(loaded.firstMeeting).toBe('08:30'); // default
-      expect(loaded.run).toBe('0'); // default
-      expect(loaded.travel).toBe('0'); // default
-      expect(loaded.breakfast).toBe('0'); // default
-      expect(loaded.location).toBe('round-town'); // default
-    });
+    assert.deepStrictEqual(loaded, location);
   });
+});
 
-  test.describe('weather location', () => {
-    test('saves and loads weather location', async ({ page }) => {
-      const loaded = await page.evaluate(async () => {
-        const { Storage } = await import('./js/core/storage.js');
-        const location = {
-          lat: 42.3601,
-          lon: -71.0589,
-          city: 'Boston',
-          tz: 'America/New_York'
-        };
-        Storage.saveWeatherLocation(location);
-        return Storage.loadWeatherLocation();
-      });
-
-      expect(loaded.lat).toBe(42.3601);
-      expect(loaded.lon).toBe(-71.0589);
-      expect(loaded.city).toBe('Boston');
-      expect(loaded.tz).toBe('America/New_York');
-    });
-
-    test('returns null for invalid location', async ({ page }) => {
-      const result = await page.evaluate(async () => {
-        const { Storage } = await import('./js/core/storage.js');
-        Storage.saveWeatherLocation({ lat: 'invalid', lon: 'invalid' });
-        return Storage.loadWeatherLocation();
-      });
-      expect(result).toBe(null);
-    });
+test('storage: invalid weather location returns null', async () => {
+  await runWithFreshStorage(() => {
+    Storage.saveWeatherLocation({ lat: 'invalid', lon: 'invalid' });
+    assert.strictEqual(Storage.loadWeatherLocation(), null);
   });
+});
 
-  test.describe('cache', () => {
-    test('saves and loads cached data', async ({ page }) => {
-      const loaded = await page.evaluate(async () => {
-        const { Storage } = await import('./js/core/storage.js');
-        const data = { weather: 'sunny', temp: 72 };
-        Storage.saveCache('test:cache', data);
-        return Storage.loadCache('test:cache', 60000);
-      });
-      expect(loaded).toEqual({ weather: 'sunny', temp: 72 });
-    });
+test('storage: cache stores and retrieves JSON data', async () => {
+  await runWithFreshStorage(() => {
+    const data = { weather: 'sunny', temp: 72 };
+    Storage.saveCache('test:cache', data);
 
-    test('returns null for expired cache', async ({ page }) => {
-      const result = await page.evaluate(async () => {
-        const { Storage } = await import('./js/core/storage.js');
-        const data = { weather: 'cloudy' };
-        Storage.saveCache('test:cache', data);
-
-        // Simulate expired cache
-        localStorage.setItem('test:cache:t', String(Date.now() - 100000));
-
-        return Storage.loadCache('test:cache', 60000);
-      });
-      expect(result).toBe(null);
-    });
-
-    test('returns null for missing cache', async ({ page }) => {
-      const result = await page.evaluate(async () => {
-        const { Storage } = await import('./js/core/storage.js');
-        return Storage.loadCache('missing:cache', 60000);
-      });
-      expect(result).toBe(null);
-    });
+    const loaded = Storage.loadCache('test:cache', 60_000);
+    assert.deepStrictEqual(loaded, data);
   });
+});
 
-  test.describe('clear', () => {
-    test('clears all stored data', async ({ page }) => {
-      const { formValues, weatherLocation } = await page.evaluate(async () => {
-        const { Storage } = await import('./js/core/storage.js');
+test('storage: expired cache returns null', async () => {
+  await runWithFreshStorage(() => {
+    Storage.saveCache('test:cache', { weather: 'cloudy' });
 
-        Storage.saveFormValues({
-          firstMeeting: '10:00',
-          run: 30
-        });
-        Storage.saveWeatherLocation({
-          lat: 40.7128,
-          lon: -74.0060
-        });
+    const staleTime = String(Date.now() - 100_000);
+    globalThis.localStorage.setItem('test:cache:t', staleTime);
 
-        Storage.clear();
+    const loaded = Storage.loadCache('test:cache', 60_000);
+    assert.strictEqual(loaded, null);
+  });
+});
 
-        return {
-          formValues: Storage.loadFormValues(),
-          weatherLocation: Storage.loadWeatherLocation()
-        };
-      });
+test('storage: missing cache returns null', async () => {
+  await runWithFreshStorage(() => {
+    assert.strictEqual(Storage.loadCache('missing:cache', 60_000), null);
+  });
+});
 
-      // Should return defaults after clear
-      expect(formValues.firstMeeting).toBe('08:30');
-      expect(weatherLocation).toBe(null);
+test('storage: clear resets stored form and weather data', async () => {
+  await runWithFreshStorage(() => {
+    Storage.saveFormValues({
+      firstMeeting: '10:00',
+      run: 30,
     });
+    Storage.saveWeatherLocation({ lat: 40.7128, lon: -74.006 });
+
+    Storage.clear();
+
+    const values = Storage.loadFormValues();
+    const location = Storage.loadWeatherLocation();
+
+    assert.deepStrictEqual(values, {
+      firstMeeting: '08:30',
+      run: '0',
+      travel: '0',
+      breakfast: '0',
+      location: 'round-town',
+    });
+    assert.strictEqual(location, null);
   });
 });

--- a/tests/unit/time.test.js
+++ b/tests/unit/time.test.js
@@ -1,129 +1,56 @@
-import { test, expect } from '@playwright/test';
+import test from 'node:test';
+import assert from 'node:assert/strict';
 
-test.describe('Time Utilities - Unit Tests', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/index-modular.html');
-  });
+import {
+  fmtTime12InZone,
+  fmtYMDInZone,
+  tomorrowYMD,
+  parseISODate,
+} from '../../js/utils/time.js';
 
-  test.describe('fmtTime12InZone', () => {
-    test('formats time in 12-hour format with timezone', async ({ page }) => {
-      const result = await page.evaluate(async () => {
-        const { fmtTime12InZone } = await import('./js/utils/time.js');
+test('time: fmtTime12InZone formats across zones', () => {
+  const date = new Date('2024-01-01T14:30:00Z');
+  assert.strictEqual(fmtTime12InZone(date, 'UTC'), '2:30 PM');
+  assert.strictEqual(fmtTime12InZone(date, 'America/New_York'), '9:30 AM');
+  assert.strictEqual(fmtTime12InZone(date, 'America/Los_Angeles'), '6:30 AM');
+});
 
-        // Create a test date: 2024-01-01 14:30:00 UTC
-        const date = new Date('2024-01-01T14:30:00Z');
+test('time: fmtTime12InZone handles noon and midnight', () => {
+  const midnight = new Date('2024-01-01T00:00:00Z');
+  const noon = new Date('2024-01-01T12:00:00Z');
 
-        return {
-          utc: fmtTime12InZone(date, 'UTC'),
-          est: fmtTime12InZone(date, 'America/New_York'),
-          pst: fmtTime12InZone(date, 'America/Los_Angeles')
-        };
-      });
+  assert.strictEqual(fmtTime12InZone(midnight, 'UTC'), '12:00 AM');
+  assert.strictEqual(fmtTime12InZone(noon, 'UTC'), '12:00 PM');
+});
 
-      expect(result.utc).toBe('2:30 PM');
-      expect(result.est).toBe('9:30 AM');
-      expect(result.pst).toBe('6:30 AM');
-    });
+test('time: fmtYMDInZone normalises to YYYY-MM-DD', () => {
+  const date = new Date('2024-07-15T14:30:00Z');
+  assert.strictEqual(fmtYMDInZone(date, 'UTC'), '2024-07-15');
+  assert.strictEqual(fmtYMDInZone(date, 'America/New_York'), '2024-07-15');
+});
 
-    test('handles midnight and noon correctly', async ({ page }) => {
-      const result = await page.evaluate(async () => {
-        const { fmtTime12InZone } = await import('./js/utils/time.js');
+test('time: fmtYMDInZone handles day boundaries', () => {
+  const date = new Date('2024-01-01T06:00:00Z');
+  assert.strictEqual(fmtYMDInZone(date, 'UTC'), '2024-01-01');
+  assert.strictEqual(fmtYMDInZone(date, 'Pacific/Honolulu'), '2023-12-31');
+  assert.strictEqual(fmtYMDInZone(date, 'Asia/Tokyo'), '2024-01-01');
+});
 
-        const midnight = new Date('2024-01-01T00:00:00Z');
-        const noon = new Date('2024-01-01T12:00:00Z');
+test('time: tomorrowYMD returns the next day', () => {
+  const originalNow = Date.now;
+  Date.now = () => new Date('2024-01-01T12:00:00Z').getTime();
+  try {
+    assert.strictEqual(tomorrowYMD('UTC'), '2024-01-02');
+  } finally {
+    Date.now = originalNow;
+  }
+});
 
-        return {
-          midnight: fmtTime12InZone(midnight, 'UTC'),
-          noon: fmtTime12InZone(noon, 'UTC')
-        };
-      });
-
-      expect(result.midnight).toBe('12:00 AM');
-      expect(result.noon).toBe('12:00 PM');
-    });
-  });
-
-  test.describe('fmtYMDInZone', () => {
-    test('formats date as YYYY-MM-DD in timezone', async ({ page }) => {
-      const result = await page.evaluate(async () => {
-        const { fmtYMDInZone } = await import('./js/utils/time.js');
-
-        // Create a test date
-        const date = new Date('2024-07-15T14:30:00Z');
-
-        return {
-          utc: fmtYMDInZone(date, 'UTC'),
-          est: fmtYMDInZone(date, 'America/New_York')
-        };
-      });
-
-      expect(result.utc).toBe('2024-07-15');
-      expect(result.est).toBe('2024-07-15');
-    });
-
-    test('handles timezone date boundaries', async ({ page }) => {
-      const result = await page.evaluate(async () => {
-        const { fmtYMDInZone } = await import('./js/utils/time.js');
-
-        // Date that crosses midnight in different timezones
-        const date = new Date('2024-01-01T06:00:00Z');
-
-        return {
-          utc: fmtYMDInZone(date, 'UTC'),
-          hawaii: fmtYMDInZone(date, 'Pacific/Honolulu'), // UTC-10, should be previous day
-          tokyo: fmtYMDInZone(date, 'Asia/Tokyo') // UTC+9, should be same day
-        };
-      });
-
-      expect(result.utc).toBe('2024-01-01');
-      expect(result.hawaii).toBe('2023-12-31');
-      expect(result.tokyo).toBe('2024-01-01');
-    });
-  });
-
-  test.describe('tomorrowYMD', () => {
-    test('returns tomorrow date in YYYY-MM-DD format', async ({ page }) => {
-      const result = await page.evaluate(async () => {
-        const { tomorrowYMD } = await import('./js/utils/time.js');
-
-        // Mock Date.now to return a consistent value
-        const originalNow = Date.now;
-        Date.now = () => new Date('2024-01-01T12:00:00Z').getTime();
-
-        const tomorrow = tomorrowYMD('UTC');
-
-        // Restore Date.now
-        Date.now = originalNow;
-
-        return tomorrow;
-      });
-
-      expect(result).toBe('2024-01-02');
-    });
-  });
-
-  test.describe('parseISODate', () => {
-    test('parses ISO date string to Date object', async ({ page }) => {
-      const result = await page.evaluate(async () => {
-        const { parseISODate } = await import('./js/utils/time.js');
-
-        const date = parseISODate('2024-01-01T14:30:00Z');
-
-        return {
-          year: date.getFullYear(),
-          month: date.getMonth(),
-          date: date.getDate(),
-          hours: date.getUTCHours(),
-          minutes: date.getUTCMinutes()
-        };
-      });
-
-      expect(result.year).toBe(2024);
-      expect(result.month).toBe(0); // January is 0
-      expect(result.date).toBe(1);
-      expect(result.hours).toBe(14);
-      expect(result.minutes).toBe(30);
-    });
-  });
-
+test('time: parseISODate creates Date instances', () => {
+  const date = parseISODate('2024-01-01T14:30:00Z');
+  assert.strictEqual(date.getFullYear(), 2024);
+  assert.strictEqual(date.getMonth(), 0);
+  assert.strictEqual(date.getDate(), 1);
+  assert.strictEqual(date.getUTCHours(), 14);
+  assert.strictEqual(date.getUTCMinutes(), 30);
 });

--- a/tests/unit/ui.test.js
+++ b/tests/unit/ui.test.js
@@ -1,96 +1,48 @@
-import { test, expect } from '@playwright/test';
+import test from 'node:test';
+import assert from 'node:assert/strict';
 
-test.describe('UI Utilities - Unit Tests', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/index-modular.html');
-  });
+import { debounce, isDirtLocation } from '../../js/modules/ui.js';
+import { wait } from './helpers/environment.js';
 
-  test.describe('isDirtLocation', () => {
-    test('identifies dirt trail locations correctly', async ({ page }) => {
-      const results = await page.evaluate(async () => {
-        const { isDirtLocation } = await import('./js/modules/ui.js');
+test('ui: isDirtLocation flags known dirt routes', () => {
+  assert.strictEqual(isDirtLocation('figure8'), true);
+  assert.strictEqual(isDirtLocation('huber'), true);
+  assert.strictEqual(isDirtLocation('tatum'), true);
+  assert.strictEqual(isDirtLocation('holmdel'), true);
 
-        return {
-          figure8: isDirtLocation('figure8'),
-          huber: isDirtLocation('huber'),
-          tatum: isDirtLocation('tatum'),
-          holmdel: isDirtLocation('holmdel'),
-          roundTown: isDirtLocation('round-town'),
-          sandyHook: isDirtLocation('sandy-hook'),
-          asbury: isDirtLocation('asbury-boardwalk'),
-          nonexistent: isDirtLocation('nonexistent')
-        };
-      });
+  assert.strictEqual(isDirtLocation('round-town'), false);
+  assert.strictEqual(isDirtLocation('sandy-hook'), false);
+  assert.strictEqual(isDirtLocation('asbury-boardwalk'), false);
+  assert.strictEqual(isDirtLocation('nonexistent'), false);
+});
 
-      // Dirt locations should return true
-      expect(results.figure8).toBe(true);
-      expect(results.huber).toBe(true);
-      expect(results.tatum).toBe(true);
-      expect(results.holmdel).toBe(true);
+test('ui: debounce delays execution until idle', async () => {
+  let callCount = 0;
+  const debounced = debounce(() => {
+    callCount += 1;
+  }, 50);
 
-      // Non-dirt locations should return false
-      expect(results.roundTown).toBe(false);
-      expect(results.sandyHook).toBe(false);
-      expect(results.asbury).toBe(false);
-      expect(results.nonexistent).toBe(false);
-    });
-  });
+  debounced();
+  debounced();
+  debounced();
 
-  test.describe('debounce', () => {
-    test('delays function execution', async ({ page }) => {
-      const result = await page.evaluate(async () => {
-        const { debounce } = await import('./js/modules/ui.js');
+  assert.strictEqual(callCount, 0);
+  await wait(80);
+  assert.strictEqual(callCount, 1);
+});
 
-        return new Promise((resolve) => {
-          let callCount = 0;
-          const testFunc = () => { callCount++; };
-          const debouncedFunc = debounce(testFunc, 100);
+test('ui: debounce resets timer on rapid calls', async () => {
+  let callCount = 0;
+  const debounced = debounce(() => {
+    callCount += 1;
+  }, 80);
 
-          // Call multiple times rapidly
-          debouncedFunc();
-          debouncedFunc();
-          debouncedFunc();
+  debounced();
 
-          // Should not have been called yet
-          const immediateCount = callCount;
+  setTimeout(() => {
+    debounced();
+  }, 40);
 
-          // Wait for debounce delay
-          setTimeout(() => {
-            resolve({ immediateCount, finalCount: callCount });
-          }, 150);
-        });
-      });
-
-      expect(result.immediateCount).toBe(0);
-      expect(result.finalCount).toBe(1);
-    });
-
-    test('cancels previous calls', async ({ page }) => {
-      const result = await page.evaluate(async () => {
-        const { debounce } = await import('./js/modules/ui.js');
-
-        return new Promise((resolve) => {
-          let callCount = 0;
-          const testFunc = () => { callCount++; };
-          const debouncedFunc = debounce(testFunc, 100);
-
-          // First call
-          debouncedFunc();
-
-          // Second call after 50ms (should cancel first)
-          setTimeout(() => {
-            debouncedFunc();
-          }, 50);
-
-          // Check result after 200ms
-          setTimeout(() => {
-            resolve(callCount);
-          }, 200);
-        });
-      });
-
-      expect(result).toBe(1); // Should only be called once
-    });
-  });
-
+  await wait(150);
+  assert.strictEqual(callCount, 1);
 });


### PR DESCRIPTION
## Summary
- replace the Playwright-based unit suite with Node's built-in test runner so it can run without browser dependencies
- add shared helpers for mocking browser APIs and update each unit test file to use `node:test`
- mark the package as an ES module and adjust the `test:unit` script to call `node --test`

## Testing
- npm run test:unit
- npm run lint:js

------
https://chatgpt.com/codex/tasks/task_e_68d575f3ceac83309feaa2687498d833