### PR TITLE
Defer awareness boot to improve page load

### DIFF
--- a/js/utils/schedulers.js
+++ b/js/utils/schedulers.js
@@ -1,0 +1,61 @@
+/**
+ * Lightweight scheduling helpers to keep the UI responsive.
+ * Provides a requestIdleCallback wrapper with a timeout fallback.
+ */
+
+const defaultTimeout = 500;
+
+const createIdleDeadline = () => ({
+  didTimeout: false,
+  timeRemaining: () => 0,
+});
+
+/**
+ * Run a callback when the browser is idle (or after a timeout fallback).
+ * @param {Function} callback
+ * @param {{ timeout?: number }} [options]
+ * @returns {number}
+ */
+export function runWhenIdle(callback, options = {}) {
+  const timeout = options.timeout ?? defaultTimeout;
+
+  if (
+    typeof window !== 'undefined' &&
+    typeof window.requestIdleCallback === 'function'
+  ) {
+    return window.requestIdleCallback(callback, { timeout });
+  }
+
+  if (
+    typeof window !== 'undefined' &&
+    typeof window.setTimeout === 'function'
+  ) {
+    return window.setTimeout(() => {
+      callback(createIdleDeadline());
+    }, timeout);
+  }
+
+  return setTimeout(() => {
+    callback(createIdleDeadline());
+  }, timeout);
+}
+
+/**
+ * Cancel an idle callback scheduled with runWhenIdle.
+ * @param {number} handle
+ */
+export function cancelWhenIdle(handle) {
+  if (
+    typeof window !== 'undefined' &&
+    typeof window.cancelIdleCallback === 'function'
+  ) {
+    window.cancelIdleCallback(handle);
+  } else if (
+    typeof window !== 'undefined' &&
+    typeof window.clearTimeout === 'function'
+  ) {
+    window.clearTimeout(handle);
+  } else {
+    clearTimeout(handle);
+  }
+}


### PR DESCRIPTION
## Summary
- add a lightweight scheduler utility to defer work until the browser is idle with safe fallbacks for non-DOM environments
- lazy load the weather awareness initialization so the main UI paints faster and add graceful error handling messaging

## Testing
- npm run lint:js
- npx playwright test tests/unit --project=chromium *(fails: Playwright browsers are not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d575ef1ef88330bade2fb964cfafa6