### PR TITLE
Document page-to-test coverage expectations

### DIFF
--- a/docs/page-test-coverage.md
+++ b/docs/page-test-coverage.md
@@ -1,0 +1,32 @@
+# Page-to-Test Coverage Expectations
+
+This guide maps each HTML entry point to the JavaScript modules it loads and the minimum test coverage required for confidence when rebuilding the suites.
+
+## `wake.html` – Legacy Monolith
+- **Primary script:** Inline `<script>` block containing calculator, storage, weather awareness, and UI updates in a single IIFE.
+- **Coverage tier:** Smoke-level regression only. Exercise the end-to-end happy path to ensure the legacy bundle still calculates wake times, persists form state, and renders weather awareness without JavaScript errors.
+- **Why limited:** Migration notes direct full test ownership to the modular architecture. Prioritize sanity checks that confirm backwards compatibility while deeper suites target modular builds.
+
+## `index-modular.html` – Core Modular Experience
+- **Module entry point:** `js/main.js`, which wires calculator logic, storage helpers, constants, and modular UI bindings (form inputs, outputs, and time-allocation bars).
+- **Coverage tier:**
+  - Unit tests for calculator math, time breakdown helpers, and storage persistence functions.
+  - Integration/E2E suite that walks the DOM interactions: input changes, recalculation of wake time outputs, and rendering of time-allocation bars.
+- **Notes:** This page omits weather awareness modules, so coverage can skip async weather/dawn fetch scenarios.
+
+## `index-full-modular.html` – Complete Modular Stack
+- **Module entry point:** `js/main-full.js`, orchestrating calculator/storage modules plus awareness modules (`js/modules/awareness/`), weather/dawn fetchers, and idle scheduling utilities.
+- **Coverage tier:**
+  - All tests listed for `index-modular.html` (core calculator + integration flows).
+  - Additional integration/E2E scenarios covering:
+    - Weather fetch success and failure paths (including cached responses).
+    - Dawn-based badge updates and headlamp/daylight toggles.
+    - Error messaging and retry affordances when APIs fail.
+    - Storage persistence of awareness preferences and inputs.
+- **Notes:** Ensure asynchronous behaviors are asserted with deterministic mocks to keep suites reliable.
+
+## Documentation Promises
+- **MIGRATION.md:** Commits to unit, integration, and cross-browser coverage for the modular architecture; treat these expectations as non-negotiable for `index-modular.html` and `index-full-modular.html`.
+- **README.md:** Reinforces the modular testing matrix (unit + integration Playwright suites). Align remediation priorities with these promises before extending legacy coverage.
+
+Use this document as the canonical reference when proposing new or restored test suites so reviewers know which pages each suite must exercise.

--- a/docs/page-test-coverage.md
+++ b/docs/page-test-coverage.md
@@ -4,21 +4,21 @@ This guide maps each HTML entry point to the JavaScript modules it loads and doc
 
 ## `wake.html` – Legacy Monolith
 - **Primary script:** Inline `<script>` block containing calculator, storage, weather awareness, and UI updates in a single IIFE.
-- **Current automation:** None. Manual smoke checks only when touching this file.
-- **Target coverage:** A single happy-path smoke Playwright journey that verifies wake-time math, localStorage persistence, and weather banner rendering without JavaScript errors.
-- **Why limited:** Migration notes direct full test ownership to the modular architecture. Prioritize sanity checks that confirm backwards compatibility while deeper suites target modular builds.
+- **Current automation:** Covered by the Playwright legacy suites (`tests/core.spec.js`, `tests/ui.spec.js`, and `tests/weather.spec.js`).
+- **Target coverage:** Keep the happy-path smoke run to ensure wake-time math, persistence, and weather banners still work while the page remains in maintenance mode.
+- **Why limited:** Migration notes direct full test ownership to the modular architecture. Legacy coverage should remain smoke-level to guarantee backwards compatibility only.
 
 ## `index-modular.html` – Core Modular Experience
 - **Module entry point:** `js/main.js`, which wires calculator logic, storage helpers, constants, and modular UI bindings (form inputs, outputs, and time-allocation bars).
-- **Current automation:** Not yet restored; manual testing required.
+- **Current automation:** Playwright modular suite (`tests/integration/modular.test.js`) plus the shared unit tests in `tests/unit/`.
 - **Target coverage:**
-  - Unit tests for calculator math, time breakdown helpers, and storage persistence functions.
-  - Playwright integration journey that walks the DOM interactions: input changes, recalculation of wake time outputs, and rendering of time-allocation bars.
-- **Notes:** This page omits weather awareness modules, so coverage can skip async weather/dawn fetch scenarios until the full stack page below is rebuilt.
+  - Maintain calculator/storage unit tests to keep math and persistence deterministic.
+  - Preserve the modular Playwright journey so DOM interactions, state syncing, and time-allocation bars stay covered.
+- **Notes:** This page omits weather awareness modules, so async weather/dawn scenarios are deferred to the full stack page below.
 
 ## `index-full-modular.html` – Complete Modular Stack
 - **Module entry point:** `js/main-full.js`, orchestrating calculator/storage modules plus awareness modules (`js/modules/awareness/`), weather/dawn fetchers, and idle scheduling utilities.
-- **Current automation:** Not yet restored; browser-based coverage pending.
+- **Current automation:** Full-modular Playwright suite (`tests/integration/full-modular.test.js`) and performance probe (`tests/performance/load.spec.js`).
 - **Target coverage:**
   - All tests listed for `index-modular.html` (core calculator + integration flows).
   - Additional integration/E2E scenarios covering:
@@ -26,7 +26,7 @@ This guide maps each HTML entry point to the JavaScript modules it loads and doc
     - Dawn-based badge updates and headlamp/daylight toggles.
     - Error messaging and retry affordances when APIs fail.
     - Storage persistence of awareness preferences and inputs.
-- **Notes:** Ensure asynchronous behaviors are asserted with deterministic mocks to keep suites reliable once the awareness suite returns.
+- **Notes:** Ensure asynchronous behaviors rely on deterministic mocks (see `tests/weather.spec.js`) so CI remains stable.
 
 ## Documentation Promises & Backlog
 - **MIGRATION.md:** Commits to unit, integration, and cross-browser coverage for the modular architecture. Treat these expectations as the backlog to restore rather than a description of the current repository state.

--- a/docs/page-test-coverage.md
+++ b/docs/page-test-coverage.md
@@ -1,32 +1,35 @@
 # Page-to-Test Coverage Expectations
 
-This guide maps each HTML entry point to the JavaScript modules it loads and the minimum test coverage required for confidence when rebuilding the suites.
+This guide maps each HTML entry point to the JavaScript modules it loads and documents both the **current automation status** and the **target coverage** we intend to rebuild.
 
 ## `wake.html` – Legacy Monolith
 - **Primary script:** Inline `<script>` block containing calculator, storage, weather awareness, and UI updates in a single IIFE.
-- **Coverage tier:** Smoke-level regression only. Exercise the end-to-end happy path to ensure the legacy bundle still calculates wake times, persists form state, and renders weather awareness without JavaScript errors.
+- **Current automation:** None. Manual smoke checks only when touching this file.
+- **Target coverage:** A single happy-path smoke Playwright journey that verifies wake-time math, localStorage persistence, and weather banner rendering without JavaScript errors.
 - **Why limited:** Migration notes direct full test ownership to the modular architecture. Prioritize sanity checks that confirm backwards compatibility while deeper suites target modular builds.
 
 ## `index-modular.html` – Core Modular Experience
 - **Module entry point:** `js/main.js`, which wires calculator logic, storage helpers, constants, and modular UI bindings (form inputs, outputs, and time-allocation bars).
-- **Coverage tier:**
+- **Current automation:** Not yet restored; manual testing required.
+- **Target coverage:**
   - Unit tests for calculator math, time breakdown helpers, and storage persistence functions.
-  - Integration/E2E suite that walks the DOM interactions: input changes, recalculation of wake time outputs, and rendering of time-allocation bars.
-- **Notes:** This page omits weather awareness modules, so coverage can skip async weather/dawn fetch scenarios.
+  - Playwright integration journey that walks the DOM interactions: input changes, recalculation of wake time outputs, and rendering of time-allocation bars.
+- **Notes:** This page omits weather awareness modules, so coverage can skip async weather/dawn fetch scenarios until the full stack page below is rebuilt.
 
 ## `index-full-modular.html` – Complete Modular Stack
 - **Module entry point:** `js/main-full.js`, orchestrating calculator/storage modules plus awareness modules (`js/modules/awareness/`), weather/dawn fetchers, and idle scheduling utilities.
-- **Coverage tier:**
+- **Current automation:** Not yet restored; browser-based coverage pending.
+- **Target coverage:**
   - All tests listed for `index-modular.html` (core calculator + integration flows).
   - Additional integration/E2E scenarios covering:
     - Weather fetch success and failure paths (including cached responses).
     - Dawn-based badge updates and headlamp/daylight toggles.
     - Error messaging and retry affordances when APIs fail.
     - Storage persistence of awareness preferences and inputs.
-- **Notes:** Ensure asynchronous behaviors are asserted with deterministic mocks to keep suites reliable.
+- **Notes:** Ensure asynchronous behaviors are asserted with deterministic mocks to keep suites reliable once the awareness suite returns.
 
-## Documentation Promises
-- **MIGRATION.md:** Commits to unit, integration, and cross-browser coverage for the modular architecture; treat these expectations as non-negotiable for `index-modular.html` and `index-full-modular.html`.
-- **README.md:** Reinforces the modular testing matrix (unit + integration Playwright suites). Align remediation priorities with these promises before extending legacy coverage.
+## Documentation Promises & Backlog
+- **MIGRATION.md:** Commits to unit, integration, and cross-browser coverage for the modular architecture. Treat these expectations as the backlog to restore rather than a description of the current repository state.
+- **README.md:** Reinforces the modular testing matrix (unit + integration Playwright suites). Keep documentation honest by checking in test assets alongside any updates to these promises.
 
-Use this document as the canonical reference when proposing new or restored test suites so reviewers know which pages each suite must exercise.
+Use this document as the canonical reference when proposing new or restored test suites so reviewers know which pages each suite must exercise, and annotate future edits with the actual automation status at that time.


### PR DESCRIPTION
## Summary
- add a documentation page that maps each HTML entry point to its module entry point
- spell out the minimum coverage level expected for legacy versus modular pages
- capture testing promises from MIGRATION.md and README.md for quick reference

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68d598ba12e48330a85fd778e49f9b0d