### PR TITLE
Document Safari-focused Playwright workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,14 @@ main-full.js
 
 ## Testing
 
-Install dependencies and browser binaries once per clone:
+Install dependencies and the WebKit binary once per clone when you only need Safari coverage:
 
 ```bash
 npm install
-npx playwright install --with-deps
+npx playwright install webkit
 ```
+
+> **Need the full Chromium/Firefox/WebKit matrix?** Continue to run `npx playwright install --with-deps` to grab every browser plus the system dependencies Playwright expects for Linux CI images.
 
 Then run the available suites:
 
@@ -99,14 +101,23 @@ Then run the available suites:
 # Playwright regression matrix across Chromium/Firefox/WebKit
 npm run test
 
+# WebKit-only regression matrix (lean install for Safari-centric debugging)
+npm run test:safari
+
 # Focus on browser flows tagged with @modular
 npm run test:modular
+
+# Restrict @modular flows to WebKit for Safari validation
+npm run test:safari:modular
 
 # Execute pure logic tests with Node's built-in runner
 npm run test:unit
 
 # Quick performance probe (single-browser budget check)
 npm run test:performance
+
+# Safari-only performance probe when chasing WebKit regressions
+npm run test:safari:performance
 
 # Structural HTML validation + linting + unit tests
 npm run validate:all


### PR DESCRIPTION
## Summary
- highlight `npx playwright install webkit` as the default install step for Safari-only debugging and keep the full matrix install as an optional note
- document the new Safari-focused npm scripts so lean WebKit test workflows are discoverable

## Testing
- npm run validate:all

------
https://chatgpt.com/codex/tasks/task_e_68d5b15ba65c8330845d0b264a84888d