### PR TITLE
Default performance tests to WebKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ npm run test:unit
 # Quick performance probe (single-browser budget check)
 npm run test:performance
 
+# Override the default WebKit run when investigating another engine
+npm run test:performance -- --project=chromium
+
 # Structural HTML validation + linting + unit tests
 npm run validate:all
 ```

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:e2e": "playwright test",
     "test:unit": "node --test tests/unit",
     "test:modular": "playwright test --grep @modular",
-    "test:performance": "playwright test tests/performance --project=chromium",
+    "test:performance": "playwright test tests/performance --project=webkit",
     "lint": "prettier --check '*.html' 'js/**/*.js'",
     "lint:js": "prettier --check 'js/**/*.js'",
     "format": "prettier --write '*.html' 'js/**/*.js'",


### PR DESCRIPTION
## Summary
- Default the `npm run test:performance` script to Playwright's WebKit project so it aligns with Safari-first environments.
- Document how to override the performance run when developers need to target a different browser.

## Testing
- [x] `npm run test:performance`
- [x] `npx playwright test tests/performance --project=webkit --reporter=line`


------
https://chatgpt.com/codex/tasks/task_e_68d5b15971208330a17c497f2bed8c8b