### PR TITLE
Streamline Safari-centric Playwright workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ npx playwright install webkit
 
 > **Need the full Chromium/Firefox/WebKit matrix?** Continue to run `npx playwright install --with-deps` to grab every browser plus the system dependencies Playwright expects for Linux CI images.
 
-Then run the available suites:
+Then run the available suites. The Playwright configuration respects a `PLAYWRIGHT_BROWSERS` environment variable so you can
+target a specific subset (for example `PLAYWRIGHT_BROWSERS=chromium npm run test:e2e`).
 
 ```bash
 # Playwright regression matrix across Chromium/Firefox/WebKit
@@ -108,16 +109,16 @@ npm run test:safari
 npm run test:modular
 
 # Restrict @modular flows to WebKit for Safari validation
-npm run test:safari:modular
+npm run test:modular:safari
 
 # Execute pure logic tests with Node's built-in runner
 npm run test:unit
 
-# Quick performance probe (single-browser budget check)
+# Quick performance probe (single-browser budget check, defaults to WebKit)
 npm run test:performance
 
-# Safari-only performance probe when chasing WebKit regressions
-npm run test:safari:performance
+# Run the performance suite in another browser as needed
+PLAYWRIGHT_BROWSERS=chromium npm run test:performance
 
 # Structural HTML validation + linting + unit tests
 npm run validate:all

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:unit": "node --test tests/unit",
     "test:modular": "playwright test --grep @modular",
     "test:modular:safari": "PLAYWRIGHT_BROWSERS=webkit npm run test:modular",
-    "test:performance": "playwright test tests/performance --project=chromium",
+    "test:performance": "PLAYWRIGHT_BROWSERS=webkit playwright test tests/performance",
     "lint": "prettier --check '*.html' 'js/**/*.js'",
     "lint:js": "prettier --check 'js/**/*.js'",
     "format": "prettier --write '*.html' 'js/**/*.js'",


### PR DESCRIPTION
## Summary
- default the performance suite to WebKit so Safari-first setups skip Chromium downloads
- document how to scope Playwright runs with the PLAYWRIGHT_BROWSERS variable and fix Safari command names in the README

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5b03544088330b90632130188a36b