### PR TITLE
Add GitHub Pages redirect to published site

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A weather-aware wake time calculator for runners. Calculates optimal wake times 
 ## Usage
 
 ### Default Experience
-Load `src/index.html` (or visit the published site) for the full weather-aware modular build.
+Load `src/index.html` locally, or visit the published site at https://njrun1804.github.io/wake-time-calculator/ for the full weather-aware modular build.
 
 ### Setup for Development
 ```bash

--- a/index.html
+++ b/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Wake Time Calculator</title>
+    <meta http-equiv="refresh" content="0; url=src/index.html" />
+    <link rel="canonical" href="src/index.html" />
+  </head>
+  <body>
+    <p>
+      Redirecting to the
+      <a href="src/index.html">Wake Time Calculator</a>
+      application.
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a root-level index.html that redirects GitHub Pages traffic to the existing src-based app
- document the published site URL in the README for easy discovery

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e07689cb148330889e20c8fe0b7090