### PR TITLE
chore: tighten Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,13 +1,27 @@
-node_modules
+# High-volume directories not needed in the runtime image
+node_modules/
+docs/
+tests/
+scripts/
+playwright-report/
+test-results/
+coverage/
+
+# Editor, VCS, and local environment files
 npm-debug.log
 .git
 .gitignore
 .vscode
 .DS_Store
-playwright-report
-test-results
 .history
 .env
 *.log
-coverage
-.husky
+.husky/
+
+# Ignore everything by default and explicitly allow what the container build needs
+**
+!Dockerfile
+!.dockerignore
+!docker-compose.yml
+!src/
+!src/**


### PR DESCRIPTION
## Summary
- update `.dockerignore` to exclude docs, tests, scripts, and other development artifacts
- restrict the Docker build context to the `src/` tree and container configuration files for smaller image builds

## Testing
- not run (Docker CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e077128998833089ce650c7286bfb9