### PR TITLE
Refactor Docker setup to reuse upstream nginx image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,7 @@ COPY src/css /usr/share/nginx/html/css
 COPY src/js /usr/share/nginx/html/js
 
 # Add nginx config for SPA routing
-RUN echo 'server { \
-    listen 80; \
-    location / { \
-        root /usr/share/nginx/html; \
-        index index.html; \
-        try_files $uri $uri/ /index.html; \
-    } \
-}' > /etc/nginx/conf.d/default.conf
+COPY docker/nginx/default.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ A weather-aware wake time calculator for runners. Calculates optimal wake times 
 ### Default Experience
 Load `src/index.html` (or visit the published site) for the full weather-aware modular build.
 
+### Docker
+
+Build the production image with the bundled static assets and SPA routing by running `docker build -t wake-time-calculator .`. Then run it with any standard container runtime.
+
+For a faster local preview that reuses the upstream `nginx:alpine` image, launch `docker-compose up app`. The compose setup now mounts the `src/` directory and the Nginx config read-only so the container starts instantly without a build step while still serving the SPA correctly.
+
 ### Setup for Development
 ```bash
 # Serve from src/ directory for ES6 module testing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,13 @@
 services:
   app:
-    build: .
+    image: nginx:alpine
     ports:
       - "8080:80"
     restart: unless-stopped
     container_name: wake-time-calculator
+    volumes:
+      - ./src:/usr/share/nginx/html:ro
+      - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:80"]
       interval: 30s

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,0 +1,8 @@
+server {
+    listen 80;
+    location / {
+        root /usr/share/nginx/html;
+        index index.html;
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- extract the SPA routing configuration into docker/nginx/default.conf so it can be shared
- update the compose app service to consume nginx:alpine with read-only mounts for source and config
- document how docker build still produces the production image while docker-compose up app now starts instantly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e07714a2dc833087ebf19a7d4ef369