### PR TITLE
Fix cache loading when timestamps are invalid

### DIFF
--- a/src/js/lib/storage.js
+++ b/src/js/lib/storage.js
@@ -133,7 +133,16 @@ export const Storage = {
    */
   loadCache(key, maxAge) {
     try {
-      const timestamp = Number(localStorage.getItem(key + ':t'));
+      const rawTimestamp = localStorage.getItem(key + ':t');
+      if (rawTimestamp === null) {
+        return null;
+      }
+
+      const timestamp = Number(rawTimestamp);
+      if (!Number.isFinite(timestamp)) {
+        return null;
+      }
+
       if (Date.now() - timestamp > maxAge) {
         return null;
       }

--- a/tests/unit/lib/storage.test.js
+++ b/tests/unit/lib/storage.test.js
@@ -342,6 +342,24 @@ describe('Storage.loadCache', () => {
     assert.equal(loaded, null);
   });
 
+  it('returns null when timestamp is missing or not numeric', () => {
+    const key = 'invalid:cache';
+    const maxAge = 3600000;
+
+    localStorage.setItem(key, '{invalid json');
+
+    const missingTimestamp = Storage.loadCache(key, maxAge);
+    assert.equal(missingTimestamp, null);
+
+    localStorage.setItem(key + ':t', null);
+    const nullTimestamp = Storage.loadCache(key, maxAge);
+    assert.equal(nullTimestamp, null);
+
+    localStorage.setItem(key + ':t', 'invalid');
+    const invalidTimestamp = Storage.loadCache(key, maxAge);
+    assert.equal(invalidTimestamp, null);
+  });
+
   it('handles corrupted JSON gracefully', () => {
     localStorage.setItem('corrupt:cache', '{invalid json');
     localStorage.setItem('corrupt:cache:t', String(Date.now()));


### PR DESCRIPTION
## Summary
- ensure `Storage.loadCache` treats missing, non-numeric, or expired timestamps as cache misses before parsing
- add unit coverage verifying null and invalid cache timestamps are skipped

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68e07726b6188330a10d76eb7ffa8a35