### PR TITLE
test: restore storage cache methods after weather API tests

### DIFF
--- a/tests/unit/app/weather/weather-api.test.js
+++ b/tests/unit/app/weather/weather-api.test.js
@@ -39,6 +39,9 @@ globalThis.fetch = async (url, options) => {
 
 // Mock Storage module
 const storageModule = await import('../../../../src/js/lib/storage.js');
+const originalLoadCache = storageModule.Storage.loadCache;
+const originalSaveCache = storageModule.Storage.saveCache;
+
 storageModule.Storage.loadCache = mockStorage.loadCache.bind(mockStorage);
 storageModule.Storage.saveCache = mockStorage.saveCache.bind(mockStorage);
 
@@ -446,6 +449,11 @@ test('fetchWetnessInputs processes snowfall data correctly', async () => {
 
 // Cleanup
 test.after(() => {
+  storageModule.Storage.loadCache = originalLoadCache;
+  storageModule.Storage.saveCache = originalSaveCache;
+  assert.strictEqual(storageModule.Storage.loadCache, originalLoadCache);
+  assert.strictEqual(storageModule.Storage.saveCache, originalSaveCache);
+
   globalThis.fetch = originalFetch;
   mockStorage.clear();
 });


### PR DESCRIPTION
## Summary
- capture the real Storage cache helpers before swapping in the in-memory mock
- restore the original cache helpers during test cleanup so other suites can rely on them
- assert the cleanup left the real methods in place to guard against regressions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1038004d88330ad3edc3f6d70845f